### PR TITLE
Support GHC 8

### DIFF
--- a/plugins.cabal
+++ b/plugins.cabal
@@ -26,6 +26,7 @@ Tested-with:        GHC == 7.0.*
                   , GHC == 7.6.*
                   , GHC == 7.8.*
                   , GHC == 7.10.*
+                  , GHC == 8.0.*
 extra-source-files: config.guess, config.h.in, config.mk.in, config.sub,
                     configure, configure.ac, install.sh, Makefile,
                     testsuite/makewith/io/TestIO.conf.in,

--- a/src/System/Plugins/Env.hs
+++ b/src/System/Plugins/Env.hs
@@ -323,7 +323,14 @@ union ls ps' =
 grabDefaultPkgConf :: IO PkgEnvs
 grabDefaultPkgConf = do
         pc <- configureAllKnownPrograms silent defaultProgramConfiguration
+#if MIN_VERSION_Cabal(1,24,0)
+        (compiler, _platform, _programConfiguration)
+           <- configure silent Nothing Nothing pc
+        pkgIndex <- getInstalledPackages silent compiler
+                        [GlobalPackageDB, UserPackageDB] pc
+#else
         pkgIndex <- getInstalledPackages silent [GlobalPackageDB, UserPackageDB] pc
+#endif
         return $ [] `union` allPackages pkgIndex
 
 --
@@ -332,7 +339,13 @@ grabDefaultPkgConf = do
 readPackageConf :: FilePath -> IO [PackageConfig]
 readPackageConf f = do
     pc <- configureAllKnownPrograms silent defaultProgramConfiguration
+#if MIN_VERSION_Cabal(1,24,0)
+    (compiler, _platform, _programConfiguration)
+       <- configure silent Nothing Nothing pc
+    pkgIndex <- getInstalledPackages silent compiler [GlobalPackageDB, UserPackageDB, SpecificPackageDB f] pc
+#else
     pkgIndex <- getInstalledPackages silent [GlobalPackageDB, UserPackageDB, SpecificPackageDB f] pc
+#endif
     return $ allPackages pkgIndex
 
 -- -----------------------------------------------------------

--- a/src/System/Plugins/Load.hs
+++ b/src/System/Plugins/Load.hs
@@ -72,11 +72,16 @@ import System.Plugins.LoadTypes
 -- import Language.Hi.Parser
 import BinIface
 import HscTypes
-#if MIN_VERSION_ghc(7,10,0)
-import Module (moduleName, moduleNameString, packageKeyString)
+
+import Module (moduleName, moduleNameString)
+#if MIN_VERSION_ghc(8,0,0)
+import Module (unitIdString)
+#elif MIN_VERSION_ghc(7,10,0)
+import Module (packageKeyString)
 #else
-import Module (moduleName, moduleNameString, packageIdString)
+import Module (packageIdString)
 #endif
+
 import HscMain (newHscEnv)
 import TcRnMonad (initTcRnIf)
 
@@ -705,7 +710,9 @@ loadDepends obj incpaths = do
 
                 -- and find some packages to load, as well.
                 let ps = dep_pkgs ds
-#if MIN_VERSION_ghc(7,10,0)
+#if MIN_VERSION_ghc(8,0,0)
+                ps' <- filterM loaded . map unitIdString . nub $ map fst ps
+#elif MIN_VERSION_ghc(7,10,0)
                 ps' <- filterM loaded . map packageKeyString . nub $ map fst ps
 #elif MIN_VERSION_ghc(7,2,0)
                 ps' <- filterM loaded . map packageIdString . nub $ map fst ps

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/master/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.8
+resolver: lts-8.0
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
I have fixed it so that it works with GHC 8. Added GHC 8 to `tested-with` in `.cabal`. The `.travis.yml` seems to be auto generated, I did not edit it; It will have to be regenerated for travis to actually test it on GHC 8.