### PR TITLE
Change homepage to github project page

### DIFF
--- a/plugins.cabal
+++ b/plugins.cabal
@@ -1,6 +1,6 @@
 name:               plugins
 version:            1.5.6.0
-homepage:           http://hub.darcs.net/stepcut/plugins
+homepage:           https://github.com/stepcut/plugins
 synopsis:           Dynamic linking for Haskell and C objects
 description:        Dynamic linking and runtime evaluation of Haskell,
                     and C, including dependency chasing and package resolution.


### PR DESCRIPTION
Given that the darcs repo hasn’t been updated in quite some time this
seems more appropriate.