### PR TITLE
Try to get this package working again.

### DIFF
--- a/plugins.cabal
+++ b/plugins.cabal
@@ -59,6 +59,7 @@ library
                           filepath,
                           random,
                           process,
+                          split,
                           ghc >= 6.10,
                           ghc-prim
 

--- a/src/System/Plugins/Consts.hs
+++ b/src/System/Plugins/Consts.hs
@@ -20,7 +20,7 @@
 
 module System.Plugins.Consts where
 
-#include "../../../config.h"
+#include "config.h"
 
 
 #if __GLASGOW_HASKELL__ >= 604

--- a/src/System/Plugins/Env.hs
+++ b/src/System/Plugins/Env.hs
@@ -40,13 +40,15 @@ module System.Plugins.Env (
         lookupMerged,
         addMerge,
         addPkgConf,
+        defaultPkgConf,
         union,
         addStaticPkg,
         isStaticPkg,
         rmStaticPkg,
         grabDefaultPkgConf,
         readPackageConf,
-        lookupPkg
+        lookupPkg,
+        pkgManglingPrefix
 
    ) where
 
@@ -59,7 +61,7 @@ import Control.Monad            ( liftM )
 
 import Data.IORef               ( writeIORef, readIORef, newIORef, IORef() )
 import Data.Maybe               ( isJust, isNothing, fromMaybe )
-import Data.List                ( (\\), nub, )
+import Data.List                ( (\\), nub )
 
 import System.IO.Unsafe         ( unsafePerformIO )
 import System.Directory         ( doesFileExist )
@@ -83,6 +85,7 @@ import Distribution.Package hiding (
                                      Module,
 #endif
                                      depends, packageName, PackageName(..)
+                                   , installedUnitId
 #if MIN_VERSION_ghc(7,10,0)
                                    , installedPackageId
 #endif
@@ -95,6 +98,9 @@ import Distribution.Simple.GHC
 import Distribution.Simple.PackageIndex
 import Distribution.Simple.Program
 import Distribution.Verbosity
+
+import System.Environment
+import Data.List.Split
 
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -305,6 +311,15 @@ addPkgConf f = do
     ps <- readPackageConf f
     modifyPkgEnv env $ \ls -> return $ union ls ps
 
+-- | This function is required when running with stack.
+defaultPkgConf :: IO ()
+defaultPkgConf = do
+  paths <- lookupEnv "GHC_PACKAGE_PATH"
+  unsetEnv "GHC_PACKAGE_PATH"
+  case paths of
+    Nothing -> return ()
+    Just s -> mapM_ addPkgConf $ splitOn ":" s
+
 --
 -- | add a new FM for the package.conf to the list of existing ones; if a package occurs multiple
 -- times, pick the one with the higher version number as the default (e.g., important for base in
@@ -407,6 +422,17 @@ lookupPkg pn = go [] pn
         (f', g') <- liftM unzip $ mapM (go (nub $ seen ++ ps)) (ps \\ seen)
         return $ (nub $ (concat f') ++ f, if static then [] else nub $ (concat g') ++ g)
 
+-- This is the prefix of mangled symbols that come from this package.
+pkgManglingPrefix :: PackageName -> IO (Maybe String)
+-- base seems to be mangled differently!
+pkgManglingPrefix "base" = return $ Just "base"
+pkgManglingPrefix p = withPkgEnvs env $ \fms -> return (go fms p)
+    where
+        go [] _       = Nothing
+        go (fm:fms) q = case lookupFM fm q of
+            Nothing -> go fms q     -- look in other pkgs
+            Just pkg -> Just $ drop 2 $ getHSLibraryName $ installedUnitId pkg
+
 data LibrarySpec
    = DLL String         -- -lLib
    | DLLPath FilePath   -- -Lpath
@@ -459,9 +485,9 @@ lookupPkg' p = withPkgEnvs env $ \fms -> go fms p
                     ldOptsPaths = [ path | Just (DLLPath path) <- ldInput ]
                     dlls        = map mkSOName (extras ++ ldOptsLibs)
 #if defined(CYGWIN) || defined(__MINGW32__)
-                    libdirs = fix_topdir (libraryDirs pkg) ++ ldOptsPaths
+                    libdirs = fix_topdir (libraryDirs pkg) ++ ldOptsPaths ++ fix_topdir (libraryDynDirs pkg)
 #else
-                    libdirs = libraryDirs pkg ++ ldOptsPaths
+                    libdirs = libraryDirs pkg ++ ldOptsPaths ++ libraryDynDirs pkg
 #endif
                 -- If we're loading dynamic libs we need the cbits to appear before the
                 -- real packages.
@@ -531,9 +557,15 @@ lookupPkg' p = withPkgEnvs env $ \fms -> go fms p
             -- Solution: look for dynamic libraries only if using -dynamic; otherwise, use static
             -- and add any other dynamic libraries found.
             dl <- findHSdlib dirs lib
-            let rdl = case dl of
-                  Just file -> Right $ Dynamic file
-                  Nothing   -> Left lib
+            rdl <- case dl of
+                  Just file -> return $ Right $ Dynamic file
+                  Nothing   -> do
+                      -- TODO Generate this suffix automatically. It's absurd we have to use the preprocessor.
+                      dynamicSuffix <- findHSdlib dirs (lib ++ "-ghc" ++ (reverse $ takeWhile (/= '-') $ reverse GHC_LIB_PATH))
+                      case dynamicSuffix of
+                             Just file -> return $ Right $ Dynamic file
+                             Nothing   -> return $ Left lib
+
             if dynonly then return rdl else do
               rsl <- findHSslib dirs lib
               return $ case rsl of

--- a/src/System/Plugins/Env.hs
+++ b/src/System/Plugins/Env.hs
@@ -50,7 +50,7 @@ module System.Plugins.Env (
 
    ) where
 
-#include "../../../config.h"
+#include "config.h"
 
 import System.Plugins.LoadTypes (Module)
 import System.Plugins.Consts           ( sysPkgSuffix )
@@ -76,7 +76,7 @@ import DynFlags (
   Way(WayDyn), dynamicGhc, ways,
 #endif
   defaultDynFlags, initDynFlags)
-import SysTools (initSysTools)
+import SysTools (initSysTools, initLlvmConfig)
 
 import Distribution.Package hiding (
 #if MIN_VERSION_ghc(7,6,0)
@@ -466,7 +466,8 @@ lookupPkg' p = withPkgEnvs env $ \fms -> go fms p
                 -- If we're loading dynamic libs we need the cbits to appear before the
                 -- real packages.
                 settings <- initSysTools (Just libdir)
-                dflags <- initDynFlags $ defaultDynFlags settings
+                llvmConfig <- initLlvmConfig (Just libdir)
+                dflags <- initDynFlags $ defaultDynFlags settings llvmConfig
                 libs <- mapM (findHSlib
 #if MIN_VERSION_ghc(7,8,0)
                               (WayDyn `elem` ways dflags || dynamicGhc)

--- a/src/System/Plugins/Load.hs
+++ b/src/System/Plugins/Load.hs
@@ -61,7 +61,7 @@ module System.Plugins.Load (
 
   ) where
 
-#include "../../../config.h"
+#include "config.h"
 
 import System.Plugins.Make             ( build )
 import System.Plugins.Env
@@ -104,7 +104,7 @@ import GHC                      ( defaultCallbacks )
 #else
 import DynFlags                 (defaultDynFlags, initDynFlags)
 import GHC.Paths                (libdir)
-import SysTools                 (initSysTools)
+import SysTools                 (initSysTools, initLlvmConfig)
 #endif
 import GHC.Ptr                  ( Ptr(..), nullPtr )
 #if !MIN_VERSION_ghc(7,4,1)
@@ -127,7 +127,8 @@ readBinIface' hi_path = do
     -- kludgy as hell
 #if MIN_VERSION_ghc(7,2,0)
     mySettings <- initSysTools (Just libdir) -- how should we really set the top dir?
-    dflags <- initDynFlags (defaultDynFlags mySettings)
+    llvmConfig <- initLlvmConfig (Just libdir)
+    dflags <- initDynFlags (defaultDynFlags mySettings llvmConfig)
     e <- newHscEnv dflags
 #else
     e <- newHscEnv defaultCallbacks undefined

--- a/src/System/Plugins/Parser.hs
+++ b/src/System/Plugins/Parser.hs
@@ -25,7 +25,7 @@ module System.Plugins.Parser (
         replaceModName
   ) where
 
-#include "../../../config.h"
+#include "config.h"
 
 import Data.List
 import Data.Char

--- a/src/System/Plugins/Utils.hs
+++ b/src/System/Plugins/Utils.hs
@@ -58,7 +58,7 @@ module System.Plugins.Utils (
   ) where
 
 
-#include "../../../config.h"
+#include "config.h"
 
 import System.Plugins.Env              ( isLoaded )
 import System.Plugins.Consts           ( objSuf, hiSuf, tmpDir )
@@ -289,7 +289,7 @@ findFile (ext:exts) file
 infixr 6 </>
 infixr 6 <.>
 
-(</>), (<.>), (<+>), (<>) :: FilePath -> FilePath -> FilePath
+(</>), (<.>), (<+>) :: FilePath -> FilePath -> FilePath
 [] </> b = b
 a  </> b = a ++ "/" ++ b
 
@@ -298,9 +298,6 @@ a  <.> b = a ++ "." ++ b
 
 [] <+> b = b
 a  <+> b = a ++ " " ++ b
-
-[] <> b = b
-a  <> b = a ++ b
 
 --
 -- | dirname : return the directory portion of a file path


### PR DESCRIPTION
Work for #8.

I do not understand the inner workings of this package at all, but I was able to fix the problems preventing it from building.  The `config.h` issue was pretty simple: the working directory Cabal was building from changed (we may need CPP to support older versions).  A few other tweaks were needed.  With these changes, it kind of works.

I also looked at some forks, and found the changes at https://github.com/abarbu/plugins/commit/5094eb02c25eda0cc228d6bacdbedbddcd116311 by @abarbu, which I tried to integrate into the current version.  I do not fully understand them, but they seem to help finding modules for the "load" operation.

Current status based on my limited testing:

1.  The "eval" operation seg-faults if you run your code interpreted, or compiled with `-dynamic`.  I tried to figure this out but got nowhere.  However, if compiled (statically), it seems to work.

2.  Running `load` from interpreted code takes about 1-2 seconds.  Running it from compiled code takes about 8-9 seconds.  I have found compiling with `-dynamic` recovers the faster behavior.  Again, I don't know how this stuff works, so have no explanation or solution.

3.  I haven't worked on any of the Stack, Travis, or deprecation issues, nor tested against versions of GHC other than 8.6.4.

So this is at least a first step.  If we put our heads together, perhaps we can bring this package back from the dead.

